### PR TITLE
Allow passing compile options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,19 +12,19 @@ function pluginError (message) {
   return new PluginError('gulp-jst-concat', message)
 }
 
-function compile (file, renameKeys) {
-  var name = file.path.replace(new RegExp(renameKeys[0]), renameKeys[1])
+function compile (file, options) {
+  var name = file.path.replace(new RegExp(options.renameKeys[0]), options.renameKeys[1])
     , contents = String(file.contents)
 
   return {
     name: name,
-    fnSource: _.template(contents).source
+    fnSource: _.template(contents, null, options.templateSettings || null).source
   }
 }
 
-function buildJSTString(files, renameKeys) {
+function buildJSTString(files, options) {
   function compileAndRender (file) {
-    var template = compile(file, renameKeys)
+    var template = compile(file, options)
     return printf('"%s": %s', template.name, template.fnSource)
   }
 
@@ -48,7 +48,7 @@ module.exports = function jstConcat(fileName, _opts) {
 
   function end () {
     /* jshint validthis: true */
-    var jstString = buildJSTString(files, opts.renameKeys)
+    var jstString = buildJSTString(files, opts)
 
     this.queue(new File({
       path: fileName,


### PR DESCRIPTION
We need to be able to use our custom escape sequences, and that was not possible before. this commit maintains the previous interface, while extending it to allow a templateSettings key which gets passed through to _.template
