### PR TITLE
Ability to set custom namespace for templates

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -22,13 +22,13 @@ function compile (file, renameKeys) {
   }
 }
 
-function buildJSTString(files, renameKeys) {
+function buildJSTString(namespace, files, renameKeys) {
   function compileAndRender (file) {
     var template = compile(file, renameKeys)
     return printf('"%s": %s', template.name, template.fnSource)
   }
 
-  return printf('this.JST = {%s};', files.map(compileAndRender).join(',\n'))
+  return printf('this.%s = {%s};', namespace, files.map(compileAndRender).join(',\n'))
 }
 
 module.exports = function jstConcat(fileName, _opts) {
@@ -37,6 +37,7 @@ module.exports = function jstConcat(fileName, _opts) {
   var defaults = { renameKeys: ['.*', '$&'] }
     , opts = _.extend({}, defaults, _opts)
     , files = []
+    , namespace = (_.has(_opts, 'namespace')) ? _opts.namespace : 'JST'
 
   function write (file) {
     /* jshint validthis: true */
@@ -48,7 +49,7 @@ module.exports = function jstConcat(fileName, _opts) {
 
   function end () {
     /* jshint validthis: true */
-    var jstString = buildJSTString(files, opts.renameKeys)
+    var jstString = buildJSTString(namespace, files, opts.renameKeys)
 
     this.queue(new File({
       path: fileName,


### PR DESCRIPTION
This is for those who don't want their templates exposed as `JST` to `window`.
For example:

``` javascript
  return gulp.src(config.jade.templates.src)
    .pipe($.jade())
    .pipe($.jstConcat('templates.js', {
      renameKeys: ['^.*views/templates/(.*).html$', '$1'],
      namespace: 'mySweetTemplates' // exposes templates to window as mySweetTemplates
    }))
    ...
```
