### PR TITLE
Keep lodash from using `with` statement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ function compile (file, renameKeys) {
 
   return {
     name: name,
-    fnSource: _.template(contents).source
+    fnSource: _.template(contents, null, { 'variable': 'data' }).source
   }
 }
 


### PR DESCRIPTION
the with statement breaks when concatenating the JST file into a bundle that contains other "use strict" scripts. This small change forces lodash templates to address vars instead of using `with`.
