### PR TITLE
Added new exportString option 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 .*.swp
 node_modules
+*.log

--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ gulp.task('JST', function () {
   gulp.src('client/app/views/**/*jade')
     .pipe(jade())
     .pipe(jstConcat('jst.js', {
-      renameKeys: ['^.*views/(.*).html$', '$1']
+      renameKeys: ['^.*views/(.*).html$', '$1'],
+      exportString: "this.JST"
     }))
     .pipe(gulp.dest('public/assets'))
 })
@@ -35,6 +36,8 @@ Given the example's option `renameKeys: ['^.*views/(.*).html$', '$1']` those vie
 will now be accessible as compiled [lodash](http://lodash.com/docs#template) template functions via
 - `JST['foo']` and
 - `JST['bar/baz']`.
+
+The `exportString` option makes it possible to put your compiled JST on to any object within your compiled template file. You can specify any object that is accessible to the file, `window.JST` or `module.exports` if you want to use it with browserify.
 
 (Please note that `gulp-jst-concat` doesn't have to be used in conjunction with `gulp-jade`. Any input-stream emitting html-ish file contents will do.)
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ gulp.task('JST', function () {
     .pipe(jstConcat('jst.js', {
       renameKeys: ['^.*views/(.*).html$', '$1'],
       exportString: "this.JST",
-	  requireLoDash: false
+	  requireLoDash: false,
+	  execTemplateFn: [ arguments ]
     }))
     .pipe(gulp.dest('public/assets'))
 })
@@ -42,6 +43,8 @@ The `exportString` option makes it possible to put your compiled JST on to any o
 
 The `requireLoDash` option adds a require statement to include [lodash](https://lodash.com). This helps when you're running your code through a transpiler/concatenator and don't include `_` on the `window` object.
 
+The `execTemplateFn` option was added to continue compatibility with [pug][]. Later versions return a string-building function that must be executed to get the proper template string. Pass an array of arguments to be applied to the string-building function. Supplying a non-array to `execTemplateFn` causes the object or value supplied to be passed to the string-building function as it's first argument.
+
 (Please note that `gulp-jst-concat` doesn't have to be used in conjunction with `gulp-jade`. Any input-stream emitting html-ish file contents will do.)
 
 
@@ -58,3 +61,5 @@ This will default to `['.*', '$&']` (i.e. a template's key will just be it's inp
 
 ## License
 MIT
+
+[pug]: http://pugjs.org

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ gulp.task('JST', function () {
     .pipe(jade())
     .pipe(jstConcat('jst.js', {
       renameKeys: ['^.*views/(.*).html$', '$1'],
-      exportString: "this.JST"
+      exportString: "this.JST",
+	  requireLoDash: false
     }))
     .pipe(gulp.dest('public/assets'))
 })
@@ -38,6 +39,8 @@ will now be accessible as compiled [lodash](http://lodash.com/docs#template) tem
 - `JST['bar/baz']`.
 
 The `exportString` option makes it possible to put your compiled JST on to any object within your compiled template file. You can specify any object that is accessible to the file, `window.JST` or `module.exports` if you want to use it with browserify.
+
+The `requireLoDash` option adds a require statement to include [lodash](https://lodash.com). This helps when you're running your code through a transpiler/concatenator and don't include `_` on the `window` object.
 
 (Please note that `gulp-jst-concat` doesn't have to be used in conjunction with `gulp-jade`. Any input-stream emitting html-ish file contents will do.)
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,67 +1,75 @@
 "use strict";
 
-var gUtil = require('gulp-util')
-  , PluginError = gUtil.PluginError
-  , File = gUtil.File
-  , through = require('through')
-  , _ = require('lodash')
-  , printf = require('util').format
+var gUtil = require( 'gulp-util' ),
+	PluginError = gUtil.PluginError,
+	File = gUtil.File,
+	through = require( 'through' ),
+	_ = require( 'lodash' ),
+	printf = require( 'util' )
+	.format
 
 
-function pluginError (message) {
-  return new PluginError('gulp-jst-concat', message)
+function pluginError( message ) {
+	return new PluginError( 'gulp-jst-concat', message )
 }
 
-function compile (file, opts) {
-  var renameKeys = opts.renameKeys;
-  var name = file.path.replace(new RegExp(renameKeys[0]), renameKeys[1])
-    , contents = String(file.contents)
+function compile( file, opts ) {
+	var renameKeys = opts.renameKeys;
+	var name = file.path.replace( new RegExp( renameKeys[ 0 ] ), renameKeys[ 1 ] ),
+		contents = String( file.contents )
 
-  return {
-    name: name,
-    fnSource: _.template(contents, null, { 'variable': 'data' }).source
-  }
+	return {
+		name: name,
+		fnSource: _.template( contents, null, {
+				'variable': 'data'
+			} )
+			.source
+	}
 }
 
-function buildJSTString(files, opts) {
-  var renameKeys = opts.renameKeys;
-  function compileAndRender (file) {
-    var template = compile(file, opts)
-    return printf('"%s": %s', template.name, template.fnSource)
-  }
+function buildJSTString( files, opts ) {
+	var renameKeys = opts.renameKeys;
 
-  return printf('%s = {%s};', opts.exportString, files.map(compileAndRender).join(',\n'))
+	function compileAndRender( file ) {
+		var template = compile( file, opts )
+		return printf( '"%s": %s', template.name, template.fnSource )
+	}
+
+	return printf( '%s = {%s};', opts.exportString, files.map( compileAndRender )
+		.join( ',\n' ) )
 }
 
-module.exports = function jstConcat(fileName, _opts) {
-  if (!fileName) throw pluginError('Missing fileName')
+module.exports = function jstConcat( fileName, _opts ) {
+	if ( !fileName ) throw pluginError( 'Missing fileName' )
 
-  var defaults = { 
-      renameKeys: ['.*', '$&'],
-      exportString: "this.JST"
-    }
-    , opts = _.extend({}, defaults, _opts)
-    , files = []
+	var defaults = {
+			renameKeys: [ '.*', '$&' ],
+			exportString: "this.JST"
+		},
+		opts = _.extend( {}, defaults, _opts ),
+		files = []
 
-  function write (file) {
-    /* jshint validthis: true */
-    if (file.isNull()) return
-    if (file.isStream()) return this.emit('error', pluginError('Streaming not supported'))
+	function write( file ) {
+		/* jshint validthis: true */
+		if ( file.isNull() ) return
+		if ( file.isStream() ) return this.emit( 'error', pluginError( 'Streaming not supported' ) )
 
-    files.push(file)
-  }
+		files.push( file )
+	}
 
-  function end () {
-    /* jshint validthis: true */
-    var jstString = buildJSTString(files, opts)
+	function end() {
+		/* jshint validthis: true */
+		var jstString = buildJSTString( files, opts )
 
-    this.queue(new File({
-      path: fileName,
-      contents: new Buffer(jstString)
-    }))
+		if ( _opts.requireLoDash ) jstString = "var _ = require('lodash')\n".concat( jstString );
 
-    this.queue(null)
-  }
+		this.queue( new File( {
+			path: fileName,
+			contents: new Buffer( jstString )
+		} ) )
 
-  return through(write, end)
+		this.queue( null )
+	}
+
+	return through( write, end )
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 var gUtil = require( 'gulp-util' ),
 	PluginError = gUtil.PluginError,
@@ -6,70 +6,94 @@ var gUtil = require( 'gulp-util' ),
 	through = require( 'through' ),
 	_ = require( 'lodash' ),
 	printf = require( 'util' )
-	.format
-
+	.format;
 
 function pluginError( message ) {
-	return new PluginError( 'gulp-jst-concat', message )
+	return new PluginError( 'gulp-jst-concat', message );
 }
 
 function compile( file, opts ) {
 	var renameKeys = opts.renameKeys;
 	var name = file.path.replace( new RegExp( renameKeys[ 0 ] ), renameKeys[ 1 ] ),
-		contents = String( file.contents )
-
+		contents = String( file.contents ),
+		supplementalSource, templateSource;
+	if ( opts.client ) {
+		var parts = contents.split( 'function template' );
+		supplementalSource = parts[ 0 ];
+		templateSource = 'function ' + parts[ 1 ];
+	}
 	return {
 		name: name,
-		fnSource: _.template( contents, {
-				'variable': 'data'
+		supplementalSource: supplementalSource,
+		fnSource: opts.client ? templateSource : _.template( contents, {
+				'variable': 'locals'
 			} )
 			.source
-	}
+	};
 }
 
 function buildJSTString( files, opts ) {
-	var renameKeys = opts.renameKeys;
-
 	function compileAndRender( file ) {
-		var template = compile( file, opts )
-		return printf( '"%s": %s', template.name, template.fnSource )
+		var template = compile( file, opts );
+		var source;
+		if ( opts.execTemplateFn ){
+			if ( !Array.isArray( opts.execTemplateFn ) ){
+				opts.execTemplateFn = [ opts.execTemplateFn ];
+			}
+			source = printf( '"%s": %s', template.name, eval( template.fnSource).apply( null, opts.execTemplateFn ) )
+		} else {
+			source = printf( '"%s": %s', template.name, template.fnSource )
+		}
+
+
+		return {
+			supplementalSource: template.supplementalSource,
+			source: printf( '"%s": %s', template.name, source )
+		};
 	}
 
-	return printf( '%s = {%s};', opts.exportString, files.map( compileAndRender )
-		.join( ',\n' ) )
+	var parsed = files.map( compileAndRender );
+
+	return {
+		declarations: printf( '%s = {%s};', opts.exportString, parsed.map( ( o ) => o.source )
+			.join( ',\n' ) ),
+		// hack to grab the longest source instead of overlaying all of the definitions
+		supplementalSource: parsed.map( ( o ) => o.supplementalSource )
+			.reduce( ( c, s ) => s.length > c.length ? s : c, '' )
+	};
 }
 
 module.exports = function jstConcat( fileName, _opts ) {
-	if ( !fileName ) throw pluginError( 'Missing fileName' )
+	if ( !fileName ) throw pluginError( 'Missing fileName' );
 
 	var defaults = {
 			renameKeys: [ '.*', '$&' ],
-			exportString: "this.JST"
+			exportString: 'this.JST'
 		},
-		opts = _.extend( {}, defaults, _opts ),
-		files = []
+		opts = _.defaults( _opts, defaults ),
+		files = [];
 
 	function write( file ) {
 		/* jshint validthis: true */
-		if ( file.isNull() ) return
-		if ( file.isStream() ) return this.emit( 'error', pluginError( 'Streaming not supported' ) )
+		if ( file.isNull() ) return;
+		if ( file.isStream() ) return this.emit( 'error', pluginError( 'Streaming not supported' ) );
 
-		files.push( file )
+		files.push( file );
 	}
 
 	function end() {
 		/* jshint validthis: true */
-		var jstString = buildJSTString( files, opts )
+		var jstStrings = buildJSTString( files, opts );
 
-		if ( _opts.requireLoDash ) jstString = "var _ = require('lodash')\n".concat( jstString );
+		if ( _opts.requireLoDash ) jstStrings.supplementalSource = "var _ = require('lodash');\n".concat( jstStrings.supplementalSource );
 
 		this.queue( new File( {
 			path: fileName,
-			contents: new Buffer( jstString )
-		} ) )
+			contents: new Buffer( jstStrings.supplementalSource.concat( '\n', jstStrings.declarations ) )
+		} ) );
 
-		this.queue( null )
+		this.queue( null );
 	}
 
-	return through( write, end )
-}
+	return through( write, end );
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,13 +30,16 @@ function buildJSTString(files, opts) {
     return printf('"%s": %s', template.name, template.fnSource)
   }
 
-  return printf('this.JST = {%s};', files.map(compileAndRender).join(',\n'))
+  return printf('%s = {%s};', opts.exportString, files.map(compileAndRender).join(',\n'))
 }
 
 module.exports = function jstConcat(fileName, _opts) {
   if (!fileName) throw pluginError('Missing fileName')
 
-  var defaults = { renameKeys: ['.*', '$&'] }
+  var defaults = { 
+      renameKeys: ['.*', '$&'],
+      exportString: "this.JST"
+    }
     , opts = _.extend({}, defaults, _opts)
     , files = []
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,7 @@ function compile (file, renameKeys) {
 
   return {
     name: name,
-    fnSource: _.template(contents).source
+    fnSource: _.template(contents, null, { 'variable': 'data' }).source
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ function compile( file, opts ) {
 
 	return {
 		name: name,
-		fnSource: _.template( contents, null, {
+		fnSource: _.template( contents, {
 				'variable': 'data'
 			} )
 			.source

--- a/lib/index.js
+++ b/lib/index.js
@@ -26,7 +26,7 @@ function compile (file, opts) {
 function buildJSTString(files, opts) {
   var renameKeys = opts.renameKeys;
   function compileAndRender (file) {
-    var template = compile(file, renameKeys)
+    var template = compile(file, opts)
     return printf('"%s": %s', template.name, template.fnSource)
   }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -40,9 +40,9 @@ function buildJSTString( files, opts ) {
 			if ( !Array.isArray( opts.execTemplateFn ) ){
 				opts.execTemplateFn = [ opts.execTemplateFn ];
 			}
-			source = printf( '"%s": %s', template.name, eval( template.fnSource).apply( null, opts.execTemplateFn ) )
+			source = eval( template.fnSource ).apply( null, opts.execTemplateFn )
 		} else {
-			source = printf( '"%s": %s', template.name, template.fnSource )
+			source = template.fnSource
 		}
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,8 @@ function pluginError (message) {
   return new PluginError('gulp-jst-concat', message)
 }
 
-function compile (file, renameKeys) {
+function compile (file, opts) {
+  var renameKeys = opts.renameKeys;
   var name = file.path.replace(new RegExp(renameKeys[0]), renameKeys[1])
     , contents = String(file.contents)
 
@@ -22,7 +23,8 @@ function compile (file, renameKeys) {
   }
 }
 
-function buildJSTString(files, renameKeys) {
+function buildJSTString(files, opts) {
+  var renameKeys = opts.renameKeys;
   function compileAndRender (file) {
     var template = compile(file, renameKeys)
     return printf('"%s": %s', template.name, template.fnSource)
@@ -48,7 +50,7 @@ module.exports = function jstConcat(fileName, _opts) {
 
   function end () {
     /* jshint validthis: true */
-    var jstString = buildJSTString(files, opts.renameKeys)
+    var jstString = buildJSTString(files, opts)
 
     this.queue(new File({
       path: fileName,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gulp-jst-concat",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"author": {
 		"name": "Patrick Gunderson",
 		"email": "patrickgunderson@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-jst-concat",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "author": {
     "name": "Tambourinecoder",
     "email": "tambourinecoder@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gulp-jst-concat",
-	"version": "0.1.3",
+	"version": "0.1.4",
 	"author": {
 		"name": "Patrick Gunderson",
 		"email": "patrickgunderson@gmail.com",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "gulp-jst-concat",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"author": {
 		"name": "Patrick Gunderson",
 		"email": "patrickgunderson@gmail.com",
@@ -8,7 +8,7 @@
 	},
 	"license": "MIT",
 	"description": "Compile underscore/lodash view templates to a single JST file",
-	"keywords": ["gulpplugin", "jst", "concat", "template", "lodash", "underscore"],
+	"keywords": ["gulp", "plugin", "jst", "concat", "template", "lodash", "underscore"],
 	"homepage": "https://github.com/gunderson/gulp-jst-concat",
 	"bugs": "https://github.com/gunderson/gulp-jst-concat/issues",
 	"repository": {

--- a/package.json
+++ b/package.json
@@ -1,42 +1,35 @@
 {
-  "name": "gulp-jst-concat",
-  "version": "0.1.0",
-  "author": {
-    "name": "Tambourinecoder",
-    "email": "tambourinecoder@gmail.com",
-    "url": "https://github.com/tambourinecoder"
-  },
-  "license": "MIT",
-  "description": "Compile underscore/lodash view templates to a single JST file",
-  "keywords": [
-    "gulpplugin",
-    "jst",
-    "concat",
-    "template",
-    "lodash",
-    "underscore"
-  ],
-  "homepage": "https://github.com/tambourinecoder/gulp-jst-concat",
-  "bugs": "https://github.com/tambourinecoder/gulp-jst-concat/issues",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/tambourinecoder/gulp-jst-concat.git"
-  },
-  "main": "lib/index",
-  "scripts": {
-    "test": "node_modules/.bin/mocha test"
-  },
-  "engines": {
-    "node": ">=0.10.0"
-  },
-  "dependencies": {
-    "gulp-util": "~2.2.14",
-    "through": "~2.3.4",
-    "lodash": "~2.4.1"
-  },
-  "devDependencies": {
-    "mocha-jshint": "0.0.7",
-    "chai": "~1.8.1",
-    "mocha": "~1.16.2"
-  }
+	"name": "gulp-jst-concat",
+	"version": "0.1.1",
+	"author": {
+		"name": "Patrick Gunderson",
+		"email": "patrickgunderson@gmail.com",
+		"url": "https://github.com/gunderson"
+	},
+	"license": "MIT",
+	"description": "Compile underscore/lodash view templates to a single JST file",
+	"keywords": ["gulpplugin", "jst", "concat", "template", "lodash", "underscore"],
+	"homepage": "https://github.com/gunderson/gulp-jst-concat",
+	"bugs": "https://github.com/gunderson/gulp-jst-concat/issues",
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/gunderson/gulp-jst-concat.git"
+	},
+	"main": "lib/index",
+	"scripts": {
+		"test": "node_modules/.bin/mocha test"
+	},
+	"engines": {
+		"node": ">=0.10.0"
+	},
+	"dependencies": {
+		"gulp-util": "*",
+		"through": "*",
+		"lodash": "*"
+	},
+	"devDependencies": {
+		"mocha-jshint": "<0.0.7",
+		"chai": "<1.8.1",
+		"mocha": "<1.16.2"
+	}
 }


### PR DESCRIPTION
The `exportString` option makes it possible to put your compiled JST on to any object within your compiled template file. You can specify any object that is accessible to the file, `window.JST` or `module.exports` if you want to use it with browserify.
